### PR TITLE
Removed 'delete belief_' from Solver destructor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,30 +12,6 @@ set(DESPOT_BUILD_POMDPX ON CACHE BOOL "Build POMDPX example")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -mfpmath=sse")
 set(CMAKE_MODULE_PATH ${CMAKE_PREFIX_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
-# Try to use the system version of TinyXML, if it is available. Otherwise, fall
-# back on the embedded version. Note that this may break linking with other
-# libraries that also dynamically link with TinyXML.
-find_package(TinyXML QUIET)
-
-if (${TinyXML_FOUND})
-  message(STATUS "Using system version of TinyXML.")
-
-  set(TinyXML_SOURCES "")
-else ()
-  message(STATUS "Using embedded version of TinyXML.")
-
-  set(TinyXML_SOURCES
-    src/util/tinyxml/tinystr.cpp
-    src/util/tinyxml/tinyxml.cpp
-    src/util/tinyxml/tinyxmlerror.cpp
-    src/util/tinyxml/tinyxmlparser.cpp
-  )
-
-  set(TinyXML_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/util/tinyxml")
-  set(TinyXML_LIBRARIES "")
-endif ()
-
-include_directories(SYSTEM ${TinyXML_INCLUDE_DIRS})
 include_directories(include)
 
 add_library("${PROJECT_NAME}" SHARED
@@ -69,7 +45,10 @@ add_library("${PROJECT_NAME}" SHARED
   src/util/random.cpp
   src/util/seeds.cpp
   src/util/util.cpp
-  ${TinyXML_SOURCES}
+  src/util/tinyxml/tinystr.cpp
+  src/util/tinyxml/tinyxml.cpp
+  src/util/tinyxml/tinyxmlerror.cpp
+  src/util/tinyxml/tinyxmlparser.cpp
 )
 target_link_libraries("${PROJECT_NAME}"
   ${TinyXML_LIBRARIES}

--- a/include/despot/ippc/client.h
+++ b/include/despot/ippc/client.h
@@ -10,8 +10,6 @@
 #include <string>
 #include <map>
 
-#include <despot/util/tinyxml/tinyxml.h>
-
 namespace despot {
 
 class Client {

--- a/include/despot/pomdpx/parser/parser.h
+++ b/include/despot/pomdpx/parser/parser.h
@@ -1,13 +1,22 @@
 #ifndef PARSER_H
 #define PARSER_H
 
-#include <despot/util/tinyxml/tinyxml.h>
 #include <despot/util/util.h>
 #include <despot/core/globals.h>
 #include <despot/pomdpx/parser/variable.h>
 #include <despot/pomdpx/parser/function.h>
 
 namespace despot {
+
+namespace util {
+namespace tinyxml {
+
+class TiXmlBase;
+class TiXmlElement;
+class TiXmlHandle;
+
+} // namespace tinyxml 
+} // namespace util
 
 #define REWARD_VAR_VALUE "rew"
 #define XML_INPUT_ERROR -1
@@ -23,6 +32,10 @@ class Parser {
 	friend class Func;
 
 private:
+  typedef util::tinyxml::TiXmlBase TiXmlBase;
+  typedef util::tinyxml::TiXmlElement TiXmlElement;
+  typedef util::tinyxml::TiXmlHandle TiXmlHandle;
+
   std::string file_name_;
 
 	// Variables
@@ -60,13 +73,10 @@ private:
 	// Convenience and sanity-check functions for POMDPX
 	TiXmlElement* GetParameterElement(TiXmlElement* func_element);
 	inline std::string GetFirstChildText(TiXmlElement* elem,
-		const char* child) const {
-		return elem->FirstChildElement(child)->GetText();
-	}
+    const char* child) const;
 	inline TiXmlElement* GetFirstChildElement(TiXmlElement* elem,
-		const char* child) const {
-		return elem->FirstChildElement(child);
-	}
+		const char* child) const;
+
 	void Ensure(bool condition, std::string message, TiXmlBase* base = NULL) const;
 	// void EnsureIdentityIsValid(TiXmlBase* base, std::vector<std::string> tokens) const; // TODO
 	int ComputeNumOfEntries(const std::vector<std::string>& instance,

--- a/include/despot/util/tinyxml/tinystr.h
+++ b/include/despot/util/tinyxml/tinystr.h
@@ -56,6 +56,10 @@
 #define TIXML_EXPLICIT
 #endif
 
+namespace despot {
+namespace util {
+namespace tinyxml {
+
 /*
  TiXmlString is an emulation of a subset of the std::string template.
  Its purpose is to allow compiling TinyXML on compilers with no or poor STL support.
@@ -320,6 +324,10 @@ public:
 	}
 
 };
+
+} // namespace tinyxml
+} // namespace util
+} // namespace despot
 
 #endif	// TIXML_STRING_INCLUDED
 #endif	// TIXML_USE_STL

--- a/include/despot/util/tinyxml/tinyxml.h
+++ b/include/despot/util/tinyxml/tinyxml.h
@@ -22,8 +22,8 @@
  distribution.
  */
 
-#ifndef TINYXML_INCLUDED
-#define TINYXML_INCLUDED
+#ifndef DESPOT_UTIL_TINYXML_INCLUDED
+#define DESPOT_UTIL_TINYXML_INCLUDED
 
 #ifdef _MSC_VER
 #pragma warning( push )
@@ -2053,4 +2053,3 @@ private:
 #endif
 
 #endif
-

--- a/include/despot/util/tinyxml/tinyxml.h
+++ b/include/despot/util/tinyxml/tinyxml.h
@@ -81,6 +81,10 @@
 #endif
 #endif
 
+namespace despot {
+namespace util {
+namespace tinyxml {
+
 class TiXmlDocument;
 class TiXmlElement;
 class TiXmlComment;
@@ -2039,6 +2043,10 @@ private:
 	int depth;
 	bool simpleTextPrint;TIXML_STRING buffer;TIXML_STRING indent;TIXML_STRING lineBreak;
 };
+
+} // namespace tinyxml
+} // namespace util
+} // namespace despot
 
 #ifdef _MSC_VER
 #pragma warning( pop )

--- a/src/core/solver.cpp
+++ b/src/core/solver.cpp
@@ -62,7 +62,6 @@ Solver::Solver(const DSPOMDP* model, Belief* belief) :
 }
 
 Solver::~Solver() {
-	cout << "Destructing Solver" << endl;
 }
 
 void Solver::Update(int action, OBS_TYPE obs) {

--- a/src/core/solver.cpp
+++ b/src/core/solver.cpp
@@ -63,7 +63,6 @@ Solver::Solver(const DSPOMDP* model, Belief* belief) :
 
 Solver::~Solver() {
 	cout << "Destructing Solver" << endl;
-	delete belief_;
 }
 
 void Solver::Update(int action, OBS_TYPE obs) {

--- a/src/ippc/client.cpp
+++ b/src/ippc/client.cpp
@@ -1,7 +1,9 @@
 #include <despot/ippc/client.h>
+#include <despot/util/tinyxml/tinyxml.h>
 #include <iostream>
 
 using namespace std;
+using namespace despot::util::tinyxml;
 
 namespace despot {
 

--- a/src/pomdpx/parser/parser.cpp
+++ b/src/pomdpx/parser/parser.cpp
@@ -2,10 +2,12 @@
 #include <time.h>
 #include <cstdlib>
 #include <despot/util/random.h>
+#include <despot/util/tinyxml/tinyxml.h>
 #include <despot/pomdpx/parser/parser.h>
 #include <despot/core/pomdp.h>
 
 using namespace std;
+using namespace despot::util::tinyxml;
 
 namespace despot {
 
@@ -1004,6 +1006,16 @@ TiXmlElement* Parser::GetParameterElement(TiXmlElement* element) {
 	Ensure(param_type == "TBL", "Only parameter type \"TBL\" is supported.\n");
 
 	return e_Parameter;
+}
+
+string Parser::GetFirstChildText(TiXmlElement* elem,
+    const char* child) const {
+  return elem->FirstChildElement(child)->GetText();
+}
+
+TiXmlElement* Parser::GetFirstChildElement(TiXmlElement* elem,
+    const char* child) const {
+  return elem->FirstChildElement(child);
 }
 
 vector<int> Parser::CreateStateUniformly() const {

--- a/src/util/tinyxml/tinystr.cpp
+++ b/src/util/tinyxml/tinystr.cpp
@@ -30,6 +30,10 @@
 
 #include <despot/util/tinyxml/tinystr.h>
 
+namespace despot {
+namespace util {
+namespace tinyxml {
+
 // Error value for find primitive
 const TiXmlString::size_type TiXmlString::npos =
 	static_cast<TiXmlString::size_type>(-1);
@@ -97,5 +101,9 @@ TiXmlString operator +(const char* a, const TiXmlString & b) {
 	tmp += b;
 	return tmp;
 }
+
+} // namespace tinyxml
+} // namespace util
+} // namespace despot
 
 #endif	// TIXML_USE_STL

--- a/src/util/tinyxml/tinyxml.cpp
+++ b/src/util/tinyxml/tinyxml.cpp
@@ -31,6 +31,10 @@
 
 #include <despot/util/tinyxml/tinyxml.h>
 
+namespace despot {
+namespace util {
+namespace tinyxml {
+
 bool TiXmlBase::condenseWhiteSpace = true;
 
 // Microsoft compiler security
@@ -1592,3 +1596,6 @@ bool TiXmlPrinter::Visit(const TiXmlUnknown& unknown) {
 	return true;
 }
 
+} // namespace tinyxml
+} // namespace util
+} // namespace despot

--- a/src/util/tinyxml/tinyxmlerror.cpp
+++ b/src/util/tinyxml/tinyxmlerror.cpp
@@ -24,6 +24,10 @@
 
 #include <despot/util/tinyxml/tinyxml.h>
 
+namespace despot {
+namespace util {
+namespace tinyxml {
+
 // The goal of the seperate error file is to make the first
 // step towards localization. tinyxml (currently) only supports
 // english error messages, but the could now be translated.
@@ -41,3 +45,7 @@ const char * TiXmlBase::errorString[TIXML_ERROR_STRING_COUNT] =
 		"Error null (0) or unexpected EOF found in input stream.",
 		"Error parsing CDATA.",
 		"Error when TiXmlDocument added to document, because TiXmlDocument can only be at the root.", };
+
+} // namespace tinyxml
+} // namespace util
+} // namespace despot

--- a/src/util/tinyxml/tinyxmlparser.cpp
+++ b/src/util/tinyxml/tinyxmlparser.cpp
@@ -37,6 +37,10 @@
 #	endif
 #endif
 
+namespace despot {
+namespace util {
+namespace tinyxml {
+
 // Note tha "PutString" hardcodes the same list. This
 // is less flexible than it appears. Changing the entries
 // or order will break putstring.
@@ -1490,3 +1494,6 @@ bool TiXmlText::Blank() const {
 	return true;
 }
 
+} // namespace tinyxml
+} // namespace util
+} // namespace despot


### PR DESCRIPTION
**This depends on #3. Merge that pull request first.**

This pull request removes `delete belief_` from the `Solver` destructor. This means that the code that creates the `Solver` now retains ownership of the initial belief state and is responsible for keeping it in scope for the lifetime of the `Solver`.

This is important for a few reasons:

- the current design prevents the user from passing in a stack allocated `Belief`
- the current design may call `delete` on a belief allocated with `new[]`
- the memory is not properly managed as it is: calling `belief()` to set the belief does not call `delete`
- `delete`ing an object that was `new`ed in a different shared library [can lead to crashes](http://stackoverflow.com/a/11937777/111426)

I experienced the last issue myself - the destructor was crashing because of this.