### PR TITLE
changed tag state output so that north is up

### DIFF
--- a/examples/cpp_models/tag/src/base/base_tag.cpp
+++ b/examples/cpp_models/tag/src/base/base_tag.cpp
@@ -766,7 +766,7 @@ void BaseTag::PrintState(const State& s, ostream& out) const {
 	int aindex = rob_[state.state_id];
 	int oindex = opp_[state.state_id];
 
-	for (int y = 0; y < floor_.num_rows(); y++) {
+	for (int y = floor_.num_rows()-1; y >= 0; y--) {
 		for (int x = 0; x < floor_.num_cols(); x++) {
 			int index = floor_.GetIndex(x, y);
 			if (index == Floor::INVALID)


### PR DESCRIPTION
Previously, when tag states were printed, the "north" direction according to the compass corresponded to the bottom of the output. This was confusing - it would make more sense (to me at least) to have "north" correspond to the top.

(I also emailed @yenan about this.)