### PR TITLE
Fix function signature in documentation

### DIFF
--- a/doc/cpp_model_doc/Tutorial on Using DESPOT with cpp model.md
+++ b/doc/cpp_model_doc/Tutorial on Using DESPOT with cpp model.md
@@ -512,7 +512,7 @@ After implementing the lower bound class the user needs to add it to the solver.
 class DSPOMDP {
 public:
     virtual ScenarioLowerBound* CreateScenarioLowerBound(string name = "DEFAULT",
-      string particle_bound_name = "DEFAULT") {
+      string particle_bound_name = "DEFAULT") const {
         if (name == "TRIVIAL" || name == "DEFAULT") {
             scenario_lower_bound_ = new TrivialParticleLowerBound(this);
         } else {
@@ -528,7 +528,7 @@ The following code adds this lower bound to `SimpleRockSample` and sets it as th
 
 ``` c++	
 ScenarioLowerBound* SimpleRockSample::CreateScenarioLowerBound(string name = "DEFAULT",
-  string particle_bound_name = "DEFAULT") {
+  string particle_bound_name = "DEFAULT") const {
     if (name == "TRIVIAL") {
         scenario_lower_bound_ = new TrivialParticleLowerBound(this);
     } else if (name == "EAST" || name == "DEFAULT") {

--- a/doc/cpp_model_doc/Tutorial on Using DESPOT with cpp model.md
+++ b/doc/cpp_model_doc/Tutorial on Using DESPOT with cpp model.md
@@ -514,7 +514,7 @@ public:
     virtual ScenarioLowerBound* CreateScenarioLowerBound(string name = "DEFAULT",
       string particle_bound_name = "DEFAULT") const {
         if (name == "TRIVIAL" || name == "DEFAULT") {
-            scenario_lower_bound_ = new TrivialParticleLowerBound(this);
+            return new TrivialParticleLowerBound(this);
         } else {
              cerr << "Unsupported scenario lower bound: " << name << endl;
              exit(0);
@@ -530,9 +530,9 @@ The following code adds this lower bound to `SimpleRockSample` and sets it as th
 ScenarioLowerBound* SimpleRockSample::CreateScenarioLowerBound(string name = "DEFAULT",
   string particle_bound_name = "DEFAULT") const {
     if (name == "TRIVIAL") {
-        scenario_lower_bound_ = new TrivialParticleLowerBound(this);
+        return new TrivialParticleLowerBound(this);
     } else if (name == "EAST" || name == "DEFAULT") {
-        scenario_lower_bound_ = new SimpleRockSampleEastPolicy(this,
+        return new SimpleRockSampleEastPolicy(this,
           new TrivialParticleLowerBound(this));
     } else {
         cerr << "Unsupported lower bound algorithm: " << name << endl;


### PR DESCRIPTION
The function of createLowerBound is [const](https://github.com/AdaCompNUS/despot/blob/56c4fd5afb8c93d036d35620fe38cb6b9e8fb117/src/interface/pomdp.cpp#L131]) but the example is missing the const qualifier