### PR TITLE
By examining Hyp-despot, there is an issue of memory leak that is caused by non-initialization of "allocated_"

### DIFF
--- a/include/despot/util/memorypool.h
+++ b/include/despot/util/memorypool.h
@@ -20,7 +20,7 @@ public:
 	}
 
 private:
-	bool allocated_;
+	bool allocated_ = false;
 };
 
 template<class T>


### PR DESCRIPTION
Initialize the 'allocated_' of the MemoryObject to avoid unexpected 'Free' or 'Allocate' operations.
For details, you can check the issue [here](https://github.com/AdaCompNUS/hyp-despot/issues/4).